### PR TITLE
Adding alpha channel

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,8 +27,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/modules )
 
 # prepare configuration file
 SET(VERSION_MAJOR "1")
-SET(VERSION_MINOR "4")
-SET(VERSION_MICRO "1")
+SET(VERSION_MINOR "5")
+SET(VERSION_MICRO "0")
 configure_file(config.h.in ../src/config.h @ONLY)
 
 # Enable release build

--- a/src/planeprojector.h
+++ b/src/planeprojector.h
@@ -35,6 +35,7 @@ private:
 
     float* planegrid_log;
     float* planegrid_real;
+    bool* planegrid_box;
     float min, max;
 
     int ix, iy;

--- a/src/plotter.cpp
+++ b/src/plotter.cpp
@@ -29,7 +29,7 @@ Plotter::Plotter(unsigned int _width, unsigned int _height) {
     this->surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, this->width, this->height);
     this->cr = cairo_create (this->surface);
 
-    this->set_background(Color(255, 252, 213, 255));
+    this->set_background(Color(255, 255, 255, 0));
 }
 
 /*

--- a/src/plotter.cpp
+++ b/src/plotter.cpp
@@ -29,14 +29,14 @@ Plotter::Plotter(unsigned int _width, unsigned int _height) {
     this->surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, this->width, this->height);
     this->cr = cairo_create (this->surface);
 
-    this->set_background(Color(255, 252, 213));
+    this->set_background(Color(255, 252, 213, 255));
 }
 
 /*
  * Sets the background color of the image
  */
 void Plotter::set_background(const Color &_color) {
-    cairo_set_source_rgb(this->cr, _color.get_r(), _color.get_g(), _color.get_b());
+    cairo_set_source_rgba(this->cr, _color.get_r(), _color.get_g(), _color.get_b(), _color.get_a());
     cairo_rectangle(this->cr, 0, 0, this->width, this->height);
     cairo_fill(this->cr);
 }
@@ -47,7 +47,7 @@ void Plotter::set_background(const Color &_color) {
  */
 void Plotter::draw_line(float xstart, float ystart, float xstop, float ystop,
                         const Color &_color, float line_width) {
-    cairo_set_source_rgb(this->cr, _color.get_r(), _color.get_g(), _color.get_b());
+    cairo_set_source_rgba(this->cr, _color.get_r(), _color.get_g(), _color.get_b(), _color.get_a());
     cairo_move_to(this->cr, xstart, ystart);
     cairo_line_to(this->cr, xstop, ystop);
     cairo_set_line_width(this->cr, line_width);
@@ -59,7 +59,7 @@ void Plotter::draw_line(float xstart, float ystart, float xstop, float ystop,
  */
 void Plotter::draw_filled_rectangle(float xstart, float ystart, float xstop, float ystop,
                                     const Color &_color) {
-    cairo_set_source_rgb(this->cr, _color.get_r(), _color.get_g(), _color.get_b());
+    cairo_set_source_rgba(this->cr, _color.get_r(), _color.get_g(), _color.get_b(), _color.get_a());
     cairo_rectangle (this->cr, xstart, ystart, xstop, ystop);
     cairo_fill(this->cr);
 }
@@ -69,7 +69,7 @@ void Plotter::draw_filled_rectangle(float xstart, float ystart, float xstop, flo
  */
 void Plotter::draw_empty_rectangle(float xstart, float ystart, float xstop, float ystop,
                                    const Color &_color, float line_width) {
-    cairo_set_source_rgb(this->cr, _color.get_r(), _color.get_g(), _color.get_b());
+    cairo_set_source_rgba(this->cr, _color.get_r(), _color.get_g(), _color.get_b(), _color.get_a());
     cairo_rectangle (this->cr, xstart, ystart, xstop, ystop);
     cairo_set_line_width(this->cr, line_width);
     cairo_stroke(this->cr);
@@ -80,7 +80,7 @@ void Plotter::draw_empty_rectangle(float xstart, float ystart, float xstop, floa
  */
 void Plotter::draw_filled_circle(float cx, float cy, float radius,
                                  const Color &_color) {
-    cairo_set_source_rgb(this->cr, _color.get_r(), _color.get_g(), _color.get_b());
+    cairo_set_source_rgba(this->cr, _color.get_r(), _color.get_g(), _color.get_b(), _color.get_a());
     cairo_arc(this->cr, cx, cy, radius, 0.0, 2 * M_PI);
     cairo_fill(this->cr);
 }
@@ -90,7 +90,7 @@ void Plotter::draw_filled_circle(float cx, float cy, float radius,
  */
 void Plotter::draw_empty_circle(float cx, float cy, float radius,
                                 const Color &_color, float line_width) {
-    cairo_set_source_rgb(this->cr, _color.get_r(), _color.get_g(), _color.get_b());
+    cairo_set_source_rgba(this->cr, _color.get_r(), _color.get_g(), _color.get_b(), _color.get_a());
     cairo_arc(this->cr, cx, cy, radius, 0.0, 2 * M_PI);
     cairo_set_line_width(this->cr, line_width);
     cairo_stroke(this->cr);
@@ -102,7 +102,7 @@ void Plotter::write(const char* filename) {
 
 void Plotter::type(float x, float y, float fontsize, float rotation, const Color &_color, const std::string &_text) {
     cairo_text_extents_t te;
-    cairo_set_source_rgb(this->cr, _color.get_r(), _color.get_g(), _color.get_b());
+    cairo_set_source_rgba(this->cr, _color.get_r(), _color.get_g(), _color.get_b(), _color.get_a());
     cairo_set_font_size(this->cr, fontsize);
     cairo_text_extents (this->cr, "a", &te);
     cairo_move_to(this->cr, x, y);
@@ -148,181 +148,181 @@ ColorScheme::ColorScheme(double _low, double _high, unsigned int scheme_id) {
 void ColorScheme::construct_scheme(unsigned int scheme_id) {
     switch(scheme_id) {
         case 0: // http://colorbrewer2.org/#type=diverging&scheme=RdBu&n=11
-            this->scheme.push_back("053061");
-            this->scheme.push_back("2166ac");
-            this->scheme.push_back("4393c3");
-            this->scheme.push_back("92c5de");
-            this->scheme.push_back("d1e5f0");
-            this->scheme.push_back("f7f7f7");
-            this->scheme.push_back("fddbc7");
-            this->scheme.push_back("f4a582");
-            this->scheme.push_back("d6604d");
-            this->scheme.push_back("b2182b");
-            this->scheme.push_back("67001f");
+            this->scheme.push_back("053061FF");
+            this->scheme.push_back("2166acFF");
+            this->scheme.push_back("4393c3FF");
+            this->scheme.push_back("92c5deFF");
+            this->scheme.push_back("d1e5f0FF");
+            this->scheme.push_back("f7f7f7FF");
+            this->scheme.push_back("fddbc7FF");
+            this->scheme.push_back("f4a582FF");
+            this->scheme.push_back("d6604dFF");
+            this->scheme.push_back("b2182bFF");
+            this->scheme.push_back("67001fFF");
         break;
         case 1: // http://colorbrewer2.org/#type=sequential&scheme=YlGnBu&n=9
-            this->scheme.push_back("ffffd9");
-            this->scheme.push_back("edf8b1");
-            this->scheme.push_back("c7e9b4");
-            this->scheme.push_back("7fcdbb");
-            this->scheme.push_back("41b6c4");
-            this->scheme.push_back("1d91c0");
-            this->scheme.push_back("225ea8");
-            this->scheme.push_back("253494");
-            this->scheme.push_back("081d58");
+            this->scheme.push_back("ffffd9FF");
+            this->scheme.push_back("edf8b1FF");
+            this->scheme.push_back("c7e9b4FF");
+            this->scheme.push_back("7fcdbbFF");
+            this->scheme.push_back("41b6c4FF");
+            this->scheme.push_back("1d91c0FF");
+            this->scheme.push_back("225ea8FF");
+            this->scheme.push_back("253494FF");
+            this->scheme.push_back("081d58FF");
         break;
         case 2: // http://colorbrewer2.org/#type=diverging&scheme=BrBG&n=11
-            this->scheme.push_back("543005");
-            this->scheme.push_back("8c510a");
-            this->scheme.push_back("bf812d");
-            this->scheme.push_back("dfc27d");
-            this->scheme.push_back("f6e8c3");
-            this->scheme.push_back("f5f5f5");
-            this->scheme.push_back("c7eae5");
-            this->scheme.push_back("80cdc1");
-            this->scheme.push_back("35978f");
-            this->scheme.push_back("01665e");
-            this->scheme.push_back("003c30");
+            this->scheme.push_back("543005FF");
+            this->scheme.push_back("8c510aFF");
+            this->scheme.push_back("bf812dFF");
+            this->scheme.push_back("dfc27dFF");
+            this->scheme.push_back("f6e8c3FF");
+            this->scheme.push_back("f5f5f5FF");
+            this->scheme.push_back("c7eae5FF");
+            this->scheme.push_back("80cdc1FF");
+            this->scheme.push_back("35978fFF");
+            this->scheme.push_back("01665eFF");
+            this->scheme.push_back("003c30FF");
         break;
         case 3: // http://colorbrewer2.org/#type=diverging&scheme=PiYG&n=11
-            this->scheme.push_back("8e0152");
-            this->scheme.push_back("c51b7d");
-            this->scheme.push_back("de77ae");
-            this->scheme.push_back("f1b6da");
-            this->scheme.push_back("fde0ef");
-            this->scheme.push_back("f7f7f7");
-            this->scheme.push_back("e6f5d0");
-            this->scheme.push_back("b8e186");
-            this->scheme.push_back("7fbc41");
-            this->scheme.push_back("4d9221");
-            this->scheme.push_back("276419");
+            this->scheme.push_back("8e0152FF");
+            this->scheme.push_back("c51b7dFF");
+            this->scheme.push_back("de77aeFF");
+            this->scheme.push_back("f1b6daFF");
+            this->scheme.push_back("fde0efFF");
+            this->scheme.push_back("f7f7f7FF");
+            this->scheme.push_back("e6f5d0FF");
+            this->scheme.push_back("b8e186FF");
+            this->scheme.push_back("7fbc41FF");
+            this->scheme.push_back("4d9221FF");
+            this->scheme.push_back("276419FF");
         break;
         case 4: // http://colorbrewer2.org/#type=diverging&scheme=RdYlGn&n=11
-            this->scheme.push_back("a50026");
-            this->scheme.push_back("d73027");
-            this->scheme.push_back("f46d43");
-            this->scheme.push_back("fdae61");
-            this->scheme.push_back("fdae61");
-            this->scheme.push_back("ffffbf");
-            this->scheme.push_back("d9ef8b");
-            this->scheme.push_back("a6d96a");
-            this->scheme.push_back("66bd63");
-            this->scheme.push_back("1a9850");
-            this->scheme.push_back("006837");
+            this->scheme.push_back("a50026FF");
+            this->scheme.push_back("d73027FF");
+            this->scheme.push_back("f46d43FF");
+            this->scheme.push_back("fdae61FF");
+            this->scheme.push_back("fdae61FF");
+            this->scheme.push_back("ffffbfFF");
+            this->scheme.push_back("d9ef8bFF");
+            this->scheme.push_back("a6d96aFF");
+            this->scheme.push_back("66bd63FF");
+            this->scheme.push_back("1a9850FF");
+            this->scheme.push_back("006837FF");
         break;
         case 5: // http://colorbrewer2.org/#type=sequential&scheme=PuBuGn&n=9
-            this->scheme.push_back("fff7fb");
-            this->scheme.push_back("ece2f0");
-            this->scheme.push_back("d0d1e6");
-            this->scheme.push_back("a6bddb");
-            this->scheme.push_back("67a9cf");
-            this->scheme.push_back("3690c0");
-            this->scheme.push_back("02818a");
-            this->scheme.push_back("016c59");
-            this->scheme.push_back("014636");
+            this->scheme.push_back("fff7fbFF");
+            this->scheme.push_back("ece2f0FF");
+            this->scheme.push_back("d0d1e6FF");
+            this->scheme.push_back("a6bddbFF");
+            this->scheme.push_back("67a9cfFF");
+            this->scheme.push_back("3690c0FF");
+            this->scheme.push_back("02818aFF");
+            this->scheme.push_back("016c59FF");
+            this->scheme.push_back("014636FF");
         break;
         case 6: http://colorbrewer2.org/#type=sequential&scheme=RdPu&n=9
-            this->scheme.push_back("fff7f3");
-            this->scheme.push_back("fde0dd");
-            this->scheme.push_back("fcc5c0");
-            this->scheme.push_back("fa9fb5");
-            this->scheme.push_back("f768a1");
-            this->scheme.push_back("dd3497");
-            this->scheme.push_back("ae017e");
-            this->scheme.push_back("7a0177");
-            this->scheme.push_back("49006a");
+            this->scheme.push_back("fff7f3FF");
+            this->scheme.push_back("fde0ddFF");
+            this->scheme.push_back("fcc5c0FF");
+            this->scheme.push_back("fa9fb5FF");
+            this->scheme.push_back("f768a1FF");
+            this->scheme.push_back("dd3497FF");
+            this->scheme.push_back("ae017eFF");
+            this->scheme.push_back("7a0177FF");
+            this->scheme.push_back("49006aFF");
         break;
         case 7: // http://tristen.ca/hcl-picker/#/hlc/6/1.05/CAF270/453B52
-            this->scheme.push_back("CAF270");
-            this->scheme.push_back("73D487");
-            this->scheme.push_back("30B097");
-            this->scheme.push_back("288993");
-            this->scheme.push_back("41607A");
-            this->scheme.push_back("453B52");
+            this->scheme.push_back("CAF270FF");
+            this->scheme.push_back("73D487FF");
+            this->scheme.push_back("30B097FF");
+            this->scheme.push_back("288993FF");
+            this->scheme.push_back("41607AFF");
+            this->scheme.push_back("453B52FF");
         break;
         case 8: // http://tristen.ca/hcl-picker/#/hlc/6/1.05/80C5F4/411D1E
-            this->scheme.push_back("80C5F4");
-            this->scheme.push_back("929ACB");
-            this->scheme.push_back("92729C");
-            this->scheme.push_back("824F6B");
-            this->scheme.push_back("653340");
-            this->scheme.push_back("411D1E");
+            this->scheme.push_back("80C5F4FF");
+            this->scheme.push_back("929ACBFF");
+            this->scheme.push_back("92729CFF");
+            this->scheme.push_back("824F6BFF");
+            this->scheme.push_back("653340FF");
+            this->scheme.push_back("411D1EFF");
         break;
         case 9: // http://tristen.ca/hcl-picker/#/hlc/6/1/21313E/EFEE69
-            this->scheme.push_back("21313E");
-            this->scheme.push_back("20575F");
-            this->scheme.push_back("268073");
-            this->scheme.push_back("53A976");
-            this->scheme.push_back("98CF6F");
-            this->scheme.push_back("EFEE69");
+            this->scheme.push_back("21313EFF");
+            this->scheme.push_back("20575FFF");
+            this->scheme.push_back("268073FF");
+            this->scheme.push_back("53A976FF");
+            this->scheme.push_back("98CF6FFF");
+            this->scheme.push_back("EFEE69FF");
         break;
         case 10: // http://tristen.ca/hcl-picker/#/clh/6/253/134695/D8C8BC
-            this->scheme.push_back("D8C8BC");
-            this->scheme.push_back("B4ABC5");
-            this->scheme.push_back("8F90C5");
-            this->scheme.push_back("6876BD");
-            this->scheme.push_back("415DAD");
-            this->scheme.push_back("134695");
+            this->scheme.push_back("D8C8BCFF");
+            this->scheme.push_back("B4ABC5FF");
+            this->scheme.push_back("8F90C5FF");
+            this->scheme.push_back("6876BDFF");
+            this->scheme.push_back("415DADFF");
+            this->scheme.push_back("134695FF");
         break;
         case 11: // http://tristen.ca/hcl-picker/#/clh/6/253/134695/D8C8BC
-            this->scheme.push_back("134695");
-            this->scheme.push_back("415DAD");
-            this->scheme.push_back("6876BD");
-            this->scheme.push_back("8F90C5");
-            this->scheme.push_back("B4ABC5");
-            this->scheme.push_back("D8C8BC");
+            this->scheme.push_back("134695FF");
+            this->scheme.push_back("415DADFF");
+            this->scheme.push_back("6876BDFF");
+            this->scheme.push_back("8F90C5FF");
+            this->scheme.push_back("B4ABC5FF");
+            this->scheme.push_back("D8C8BCFF");
         break;
         case 12: // http://gka.github.io/palettes/#diverging|c0=darkred,deeppink,lightyellow|c1=lightyellow,lightgreen,teal|steps=13|bez0=1|bez1=1|coL0=1|coL1=1
-            this->scheme.push_back("008080");
-            this->scheme.push_back("399785");
-            this->scheme.push_back("5aaf8c");
-            this->scheme.push_back("7ac696");
-            this->scheme.push_back("9edba4");
-            this->scheme.push_back("c7f0ba");
-            this->scheme.push_back("ffffe0");
-            this->scheme.push_back("ffd1c9");
-            this->scheme.push_back("fea0ac");
-            this->scheme.push_back("ef738b");
-            this->scheme.push_back("d84765");
-            this->scheme.push_back("b61d39");
-            this->scheme.push_back("8b0000");
+            this->scheme.push_back("008080FF");
+            this->scheme.push_back("399785FF");
+            this->scheme.push_back("5aaf8cFF");
+            this->scheme.push_back("7ac696FF");
+            this->scheme.push_back("9edba4FF");
+            this->scheme.push_back("c7f0baFF");
+            this->scheme.push_back("ffffe0FF");
+            this->scheme.push_back("ffd1c9FF");
+            this->scheme.push_back("fea0acFF");
+            this->scheme.push_back("ef738bFF");
+            this->scheme.push_back("d84765FF");
+            this->scheme.push_back("b61d39FF");
+            this->scheme.push_back("8b0000FF");
         break;
         case 13: // http://gka.github.io/palettes/#diverging|c0=darkred,lightyellow|c1=lightyellow,lightgreen,teal|steps=13|bez0=1|bez1=1|coL0=1|coL1=1
-            this->scheme.push_back("008080");
-            this->scheme.push_back("399785");
-            this->scheme.push_back("5aaf8c");
-            this->scheme.push_back("7ac696");
-            this->scheme.push_back("9edba4");
-            this->scheme.push_back("c7f0ba");
-            this->scheme.push_back("ffffe0");
-            this->scheme.push_back("f1d7b7");
-            this->scheme.push_back("e2b08f");
-            this->scheme.push_back("cf8a69");
-            this->scheme.push_back("bb6345");
-            this->scheme.push_back("a43c23");
-            this->scheme.push_back("8b0000");
+            this->scheme.push_back("008080FF");
+            this->scheme.push_back("399785FF");
+            this->scheme.push_back("5aaf8cFF");
+            this->scheme.push_back("7ac696FF");
+            this->scheme.push_back("9edba4FF");
+            this->scheme.push_back("c7f0baFF");
+            this->scheme.push_back("ffffe0FF");
+            this->scheme.push_back("f1d7b7FF");
+            this->scheme.push_back("e2b08fFF");
+            this->scheme.push_back("cf8a69FF");
+            this->scheme.push_back("bb6345FF");
+            this->scheme.push_back("a43c23FF");
+            this->scheme.push_back("8b0000FF");
         break;
         case 14: // http://paletton.com/#uid=52T0M0kkJlXa9xzfrrfq5gAvubc
-            this->scheme.push_back("96A93C");
-            this->scheme.push_back("2F8441");
-            this->scheme.push_back("2F4C73");;
+            this->scheme.push_back("96A93CFF");
+            this->scheme.push_back("2F8441FF");
+            this->scheme.push_back("2F4C73FF");;
         break;
         case 15: // black and white
-            this->scheme.push_back("000000");
-            this->scheme.push_back("FFFFFF");
+            this->scheme.push_back("000000FF");
+            this->scheme.push_back("FFFFFFFF");
         break;
         default:
-            this->scheme.push_back("053061");
-            this->scheme.push_back("2166ac");
-            this->scheme.push_back("4393c3");
-            this->scheme.push_back("92c5de");
-            this->scheme.push_back("d1e5f0");
-            this->scheme.push_back("f7f7f7");
-            this->scheme.push_back("fddbc7");
-            this->scheme.push_back("f4a582");
-            this->scheme.push_back("d6604d");
-            this->scheme.push_back("b2182b");
-            this->scheme.push_back("67001f");
+            this->scheme.push_back("053061FF");
+            this->scheme.push_back("2166acFF");
+            this->scheme.push_back("4393c3FF");
+            this->scheme.push_back("92c5deFF");
+            this->scheme.push_back("d1e5f0FF");
+            this->scheme.push_back("f7f7f7FF");
+            this->scheme.push_back("fddbc7FF");
+            this->scheme.push_back("f4a582FF");
+            this->scheme.push_back("d6604dFF");
+            this->scheme.push_back("b2182bFF");
+            this->scheme.push_back("67001fFF");
         break;
     }
 }
@@ -344,9 +344,19 @@ void ColorScheme::convert_scheme() {
  *
  */
 Color ColorScheme::rgb2color(const std::string &_hex) {
-    return Color(this->hex2int(_hex.substr(0,2)),
-                 this->hex2int(_hex.substr(2,2)),
-                 this->hex2int(_hex.substr(4,2)));
+    if(_hex.size() == 6) {
+        return Color(this->hex2int(_hex.substr(0,2)),
+                     this->hex2int(_hex.substr(2,2)),
+                     this->hex2int(_hex.substr(4,2)),
+                     255);
+    } else if(_hex.size() == 8) {
+        return Color(this->hex2int(_hex.substr(0,2)),
+                     this->hex2int(_hex.substr(2,2)),
+                     this->hex2int(_hex.substr(4,2)),
+                     this->hex2int(_hex.substr(6,2)));
+    } else {
+        throw std::runtime_error("Invalid hex color code received: " + _hex);
+    }
 }
 
 /**
@@ -372,8 +382,9 @@ Color ColorScheme::get_color(double _value) {
     float r = residual * this->colors[bin+1].get_r() + (1.0-residual) * this->colors[bin].get_r();
     float g = residual * this->colors[bin+1].get_g() + (1.0-residual) * this->colors[bin].get_g();
     float b = residual * this->colors[bin+1].get_b() + (1.0-residual) * this->colors[bin].get_b();
+    float a = residual * this->colors[bin+1].get_a() + (1.0-residual) * this->colors[bin].get_a();
 
-    return Color(r*255,g*255,b*255);
+    return Color(r*255, g*255, b*255, a*255);
 }
 
 /**
@@ -396,11 +407,22 @@ unsigned int ColorScheme::hex2int(const std::string &_hex) {
  * Color constructor
  *
  */
-Color::Color(unsigned int _r, unsigned int _g, unsigned int _b) {
-    this->r = _r;
-    this->g = _g;
-    this->b = _b;
-}
+Color::Color(unsigned int _r, unsigned int _g, unsigned int _b) :
+    r(_r),
+    g(_g),
+    b(_b),
+    a(255) {}
+
+/**
+ *
+ * Color constructor
+ *
+ */
+Color::Color(unsigned int _r, unsigned int _g, unsigned int _b, unsigned int _a) :
+    r(_r),
+    g(_g),
+    b(_b),
+    a(_a) {}
 
 /**
  *
@@ -427,4 +449,13 @@ float Color::get_g() const {
  */
 float Color::get_b() const {
     return this->b / 255.0f;
+}
+
+/**
+ *
+ * Return the integer value for alpha (divide by 255 because we want on the [0,1] interval)
+ *
+ */
+float Color::get_a() const {
+    return this->a / 255.0f;
 }

--- a/src/plotter.h
+++ b/src/plotter.h
@@ -30,12 +30,15 @@
 
 class Color {
 private:
-    unsigned int r,g,b;
+    unsigned int r,g,b,a;
 public:
     Color(unsigned int _r, unsigned int _g, unsigned int _b);
+
+    Color(unsigned int _r, unsigned int _g, unsigned int _b, unsigned int _a);
     float get_r() const;
     float get_g() const;
     float get_b() const;
+    float get_a() const;
 };
 
 class ColorScheme {

--- a/src/scalar_field.h
+++ b/src/scalar_field.h
@@ -78,7 +78,30 @@ public:
 
     void read_header_and_atoms();
 
+    /*
+     * float get_value_interp(x,y,z)
+     *
+     * Grabs a value from the 3D scalar field. Calculate the value
+     * by using a trilinear interpolation.
+     *
+     * The trilinear interpolation algorithm has been extracted from:
+     * http://paulbourke.net/miscellaneous/interpolation/
+     *
+     * Future algorithm can make use of a cubic interpolation.
+     *
+     */
     float get_value_interp(float x, float y, float z) const;
+
+    /**
+     * @brief      test whether point is inside unit cell
+     *
+     * @param[in]  x     x position
+     * @param[in]  y     y position
+     * @param[in]  z     z position
+     *
+     * @return     True if inside, False otherwise.
+     */
+    bool is_inside(float x, float y, float z) const;
 
     float get_value(unsigned int i, unsigned int j, unsigned int k) const;
 


### PR DESCRIPTION
Previously, projections on the plane that correspond to grid point outside the unit cell were plotted as if they had a value of 0.0. With this new implementation, values outside the unit cell are automatically printed as fully transparent (0,0,0,0).

Furthermore, the color schemes have been expanded with an alpha channel and thus the corresponding hex codes for the colors are 8 characters wide. The last 2 characters then correspond to the alpha channel. Similar to the RGB channels, the alpha channels of two neighboring colors in the color scheme will be mixed when plotting.